### PR TITLE
Fixed price format for label templates.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -28,6 +28,13 @@ class Admin {
   ];
 
   /**
+   * Price suffix, instead of ',00'.
+   *
+   * @string
+   */
+  const PRICE_SUFFIX = ',-';
+
+  /**
    * Size of QR code to include in the PDF label document.
    *
    * @integer
@@ -138,12 +145,12 @@ class Admin {
     }
 
     $formatted_regular_price = wc_price($regular_price, ['price_format' => '%1$s&nbsp;%2$s']);
-    // Replace ",00" with ",-".
-    $formatted_regular_price = preg_replace('@,00@', ',–', $formatted_regular_price);
+    // Replace ",00".
+    $formatted_regular_price = preg_replace('@,00@', static::PRICE_SUFFIX, $formatted_regular_price);
 
     $formatted_sale_price = wc_price($sale_price, ['price_format' => '%1$s&nbsp;%2$s']);
-    // Replace ",00" with ",-".
-    $formatted_sale_price = preg_replace('@,00@', ',–', $formatted_sale_price);
+    // Replace ",00".
+    $formatted_sale_price = preg_replace('@,00@', static::PRICE_SUFFIX, $formatted_sale_price);
 
     $data = [
       'orientation' => $labelFormat[1],

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -28,13 +28,6 @@ class Admin {
   ];
 
   /**
-   * Price suffix, instead of ',00'.
-   *
-   * @string
-   */
-  const PRICE_SUFFIX = ',-';
-
-  /**
    * Size of QR code to include in the PDF label document.
    *
    * @integer
@@ -144,13 +137,12 @@ class Admin {
       $discount_percentage = 0;
     }
 
+    $price_suffix = ',-';
     $formatted_regular_price = wc_price($regular_price, ['price_format' => '%1$s&nbsp;%2$s']);
-    // Replace ",00".
-    $formatted_regular_price = preg_replace('@,00@', static::PRICE_SUFFIX, $formatted_regular_price);
-
+    // Replace ",00" with ",-".
+    $formatted_regular_price = preg_replace('@,00@', $price_suffix, $formatted_regular_price);
     $formatted_sale_price = wc_price($sale_price, ['price_format' => '%1$s&nbsp;%2$s']);
-    // Replace ",00".
-    $formatted_sale_price = preg_replace('@,00@', static::PRICE_SUFFIX, $formatted_sale_price);
+    $formatted_sale_price = preg_replace('@,00@', $price_suffix, $formatted_sale_price);
 
     $data = [
       'orientation' => $labelFormat[1],


### PR DESCRIPTION
### Task
[Format A3 landscape is portrait](https://app.asana.com/0/587433704548192/1133452991519448/f)

### Description
"Dash" character used in substitution of ",00" in prices looked too big.