### PR TITLE
Fixed administrators were not allowed to print price labels.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.2.1",
   "title": "woocommerce-price-labels",
   "description": "Generates price labels as PDFs for WooCommerce products.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: WooCommerce Price Labels
-  Version: 1.2.0
+  Version: 1.2.1
   Text Domain: woocommerce-price-labels
   Description: Generates price labels as PDFs for WooCommerce products.
   Author: netzstrategen

--- a/src/Label.php
+++ b/src/Label.php
@@ -66,7 +66,9 @@ class Label {
    *   Roles that can print products price labels.
    */
   public static function getRolesCanPrintPriceLabel() {
-    return defined('ROLES_CAN_PRINT_PRICE_LABEL') && ROLES_CAN_PRINT_PRICE_LABEL ? ROLES_CAN_PRINT_PRICE_LABEL : ['sale-editor'];
+    return defined('ROLES_CAN_PRINT_PRICE_LABEL') && ROLES_CAN_PRINT_PRICE_LABEL ?
+      ROLES_CAN_PRINT_PRICE_LABEL :
+      ['sale-editor', 'administrator'];
   }
 
   /**


### PR DESCRIPTION
### Task

- ["Sales-Editor" role must be able to print/download the "PDF sales label" ](https://app.asana.com/0/30156186242982/1160130064551050/f)