### PR TITLE
Fixed allowed users could not print price labels from frontend.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.2.2",
   "title": "woocommerce-price-labels",
   "description": "Generates price labels as PDFs for WooCommerce products.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: WooCommerce Price Labels
-  Version: 1.2.1
+  Version: 1.2.2
   Text Domain: woocommerce-price-labels
   Description: Generates price labels as PDFs for WooCommerce products.
   Author: netzstrategen
@@ -39,3 +39,12 @@ register_uninstall_hook(__FILE__, __NAMESPACE__ . '\Schema::uninstall');
 add_action('plugins_loaded', __NAMESPACE__ . '\Plugin::loadTextdomain');
 add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
 add_action('admin_init', __NAMESPACE__ . '\Admin::init');
+
+// Capability 'edit-posts' is required to trigger the custom action to print
+// products price labels. It is temporarily added to the 'sale-editor' role,
+// but it will be removed as soon as the label is to be printed, to prevent
+// unauthorised access to the site backend.
+$action = $_GET['action'] ?? '';
+if ($action === 'label') {
+  get_role('sale-editor')->add_cap('edit_posts', TRUE);
+}

--- a/src/Label.php
+++ b/src/Label.php
@@ -88,12 +88,14 @@ class Label {
    *
    * @implements post_action_{$action}
    */
-  public static function post_action_label($post_id) {
-    if (!current_user_can('print_price_label')) {
+  public static function post_action_label($post_id = 0) {
+    // Removes the capability 'edit_posts' from role 'sale-editor' to prevent
+    // unauthorised access to the site backend.
+    get_role('sale-editor')->remove_cap('edit_posts', TRUE);
+
+    if (!current_user_can('print_price_label') || !$post_id || !$product = wc_get_product($post_id)) {
       return;
     }
-
-    $product = wc_get_product($post_id);
 
     $regular_price = $product->get_regular_price();
     $sale_price = $product->get_sale_price() ?: $regular_price;


### PR DESCRIPTION
### Task
- ["Sales-Editor" role must be able to print/download the "PDF sales label"](https://app.asana.com/0/587433704548192/1160130064551050/f)